### PR TITLE
Add Git filter that automatically strips the development team from the Xcode project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 # Windows files should use crlf line endings
 # https://help.github.com/articles/dealing-with-line-endings/
 *.bat text eol=crlf
+
+# We want to strip the development team from the committed
+# Xcode project
+*.pbxproj filter=xcodeTeam

--- a/ios/MoneyBoy.xcodeproj/project.pbxproj
+++ b/ios/MoneyBoy.xcodeproj/project.pbxproj
@@ -805,7 +805,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = X7TM82FK3L;
+				DEVELOPMENT_TEAM = <DEVTEAM_PLACEHOLDER>;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = MoneyBoy/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -834,7 +834,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = X7TM82FK3L;
+				DEVELOPMENT_TEAM = <DEVTEAM_PLACEHOLDER>;
 				INFOPLIST_FILE = MoneyBoy/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 0.1.0;

--- a/ios/MoneyBoy.xcodeproj/project.pbxproj
+++ b/ios/MoneyBoy.xcodeproj/project.pbxproj
@@ -805,7 +805,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = <DEVTEAM_PLACEHOLDER>;
+				DEVELOPMENT_TEAM = iOS Developer;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = MoneyBoy/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -834,7 +834,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = <DEVTEAM_PLACEHOLDER>;
+				DEVELOPMENT_TEAM = iOS Developer;
 				INFOPLIST_FILE = MoneyBoy/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 0.1.0;

--- a/ios/MoneyBoy.xcodeproj/project.pbxproj
+++ b/ios/MoneyBoy.xcodeproj/project.pbxproj
@@ -805,7 +805,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = iOS Developer;
+				DEVELOPMENT_TEAM = "iOS Developer";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = MoneyBoy/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -834,7 +834,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = iOS Developer;
+				DEVELOPMENT_TEAM = "iOS Developer";
 				INFOPLIST_FILE = MoneyBoy/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 0.1.0;

--- a/scripts/recheckout-xcodeproj
+++ b/scripts/recheckout-xcodeproj
@@ -7,13 +7,15 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-repo_path=$(cd $(dirname $0)/..; pwd -P)
-proj_path="$repo_path/ios/MoneyBoy.xcodeproj/project.pbxproj"
+cd $(dirname $0)/..
+
+proj_path="$PWD/ios/MoneyBoy.xcodeproj/project.pbxproj"
 
 if [ ! -f "$proj_path" ]; then
     echo "Could not find the Xcode project at $proj_path."
     exit 1
 fi
 
+echo "Re-checking out $proj_path"
 rm "$proj_path"
 git checkout "$proj_path"

--- a/scripts/recheckout-xcodeproj
+++ b/scripts/recheckout-xcodeproj
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+# Checks out the Xcode project again.
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Please make sure everything is committed!"
+    exit 1
+fi
+
+repo_path=$(cd $(dirname $0)/..; pwd -P)
+proj_path="$repo_path/ios/MoneyBoy.xcodeproj/project.pbxproj"
+
+if [ ! -f "$proj_path" ]; then
+    echo "Could not find the Xcode project at $proj_path."
+    exit 1
+fi
+
+rm "$proj_path"
+git checkout "$proj_path"

--- a/scripts/setup-xcode-filter
+++ b/scripts/setup-xcode-filter
@@ -5,7 +5,7 @@
 # added to the staging area and automatically reinserts it upon
 # checkout.
 
-DEVTEAM_PLACEHOLDER='<DEVTEAM_PLACEHOLDER>'
+DEVTEAM_PLACEHOLDER='iOS Developer'
 DEVTEAM_FIELD_PREFIX='DEVELOPMENT_TEAM\s*=\s*'
 FILTER_NAME='xcodeTeam'
 

--- a/scripts/setup-xcode-filter
+++ b/scripts/setup-xcode-filter
@@ -6,6 +6,7 @@
 # checkout.
 
 DEVTEAM_PLACEHOLDER='<DEVTEAM_PLACEHOLDER>'
+DEVTEAM_FIELD_PREFIX='DEVELOPMENT_TEAM\s*=\s*'
 FILTER_NAME='xcodeTeam'
 
 set -e
@@ -18,8 +19,8 @@ if [ -z "$devteam" ]; then
     exit 1
 fi
 
-git config filter.$FILTER_NAME.clean "sed 's/\\(DEVELOPMENT_TEAM\s*=\s*\\)\\(\w\+\\)/\1$DEVTEAM_PLACEHOLDER/'"
-git config filter.$FILTER_NAME.smudge "sed 's/$DEVTEAM_PLACEHOLDER/$devteam/'"
+git config filter.$FILTER_NAME.clean "sed 's/\\($DEVTEAM_FIELD_PREFIX\\)\\(\w\+\\)/\1$DEVTEAM_PLACEHOLDER/'"
+git config filter.$FILTER_NAME.smudge "sed 's/\\($DEVTEAM_FIELD_PREFIX\\)$DEVTEAM_PLACEHOLDER/\1$devteam/'"
 
 echo "Configured Git filter '$FILTER_NAME' to use team '$devteam'"
 echo "You may now want to re-checkout the Xcode project using 'scripts/recheckout-xcodeproj'"

--- a/scripts/setup-xcode-filter
+++ b/scripts/setup-xcode-filter
@@ -21,4 +21,5 @@ fi
 git config filter.$FILTER_NAME.clean "sed 's/\\(DEVELOPMENT_TEAM\s*=\s*\\)\\(\w\+\\)/\1$DEVTEAM_PLACEHOLDER/'"
 git config filter.$FILTER_NAME.smudge "sed 's/$DEVTEAM_PLACEHOLDER/$devteam/'"
 
-echo "Configured Git filter $FILTER_NAME to use team $devteam"
+echo "Configured Git filter '$FILTER_NAME' to use team '$devteam'"
+echo "You may now want to re-checkout the Xcode project using 'scripts/recheckout-xcodeproj'"

--- a/scripts/setup-xcode-filter
+++ b/scripts/setup-xcode-filter
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+# Sets up a Git smudge/clean filter that automatically strips
+# the Xcode Development Team before the Xcode project is
+# added to the staging area and automatically reinserts it upon
+# checkout.
+
+DEVTEAM_PLACEHOLDER='<DEVTEAM_PLACEHOLDER>'
+FILTER_NAME='xcodeTeam'
+
+set -e
+cd $(dirname $0)
+
+devteam=$1
+
+if [ -z "$devteam" ]; then
+    echo "Usage: $0 [development team id, e.g. XXXXXXXXXX]"
+    exit 1
+fi
+
+git config filter.$FILTER_NAME.clean "sed 's/\\(DEVELOPMENT_TEAM\s*=\s*\\)\\(\w\+\\)/\1$DEVTEAM_PLACEHOLDER/'"
+git config filter.$FILTER_NAME.smudge "sed 's/$DEVTEAM_PLACEHOLDER/$devteam/'"
+
+echo "Configured Git filter $FILTER_NAME to use team $devteam"

--- a/scripts/setup-xcode-filter
+++ b/scripts/setup-xcode-filter
@@ -5,7 +5,7 @@
 # added to the staging area and automatically reinserts it upon
 # checkout.
 
-DEVTEAM_PLACEHOLDER='iOS Developer'
+DEVTEAM_PLACEHOLDER='"iOS Developer"'
 DEVTEAM_FIELD_PREFIX='DEVELOPMENT_TEAM\s*=\s*'
 FILTER_NAME='xcodeTeam'
 

--- a/scripts/setup-xcode-filter
+++ b/scripts/setup-xcode-filter
@@ -19,7 +19,7 @@ if [ -z "$devteam" ]; then
     exit 1
 fi
 
-git config filter.$FILTER_NAME.clean "sed 's/\\($DEVTEAM_FIELD_PREFIX\\)\\(\w\+\\)/\1$DEVTEAM_PLACEHOLDER/'"
+git config filter.$FILTER_NAME.clean "sed 's/\\($DEVTEAM_FIELD_PREFIX\\).*;/\1$DEVTEAM_PLACEHOLDER;/'"
 git config filter.$FILTER_NAME.smudge "sed 's/\\($DEVTEAM_FIELD_PREFIX\\)$DEVTEAM_PLACEHOLDER/\1$devteam/'"
 
 echo "Configured Git filter '$FILTER_NAME' to use team '$devteam'"


### PR DESCRIPTION
Add a [smudge and clean Git filter](https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#filters_a) to automatically remove the development team from the committed Xcode project.

The following scripts can now be used to set up a local environment with a custom development team:

```bash
scripts/setup-xcode-filter [your team id]
scripts/recheckout-xcodeproj
```

To do:

- [ ] Update `DevelopmentTeam =` too in `project.pbxproj`
- [ ] Add another filter for the bundle identifier, since it seems to be tied to the team