### PR TITLE
Add generic setup script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[scripts/*]
+indent_size = 4
+
 [*.gradle]
 indent_size = 4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,13 +13,12 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
-    - name: Install npm dependencies
-      run: npm ci
     - name: Install Ruby and Fastlane
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
-        bundler-cache: true # runs `bundle install`
+    - name: Set up environment (dependencies)
+      run: scripts/setup --android --ci
     - name: Build the app
       run: bundle exec fastlane build
       working-directory: android

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
-    - name: Install Ruby and Fastlane
+    - name: Install Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,12 +13,8 @@ jobs:
       with:
         node-version: 16.x
         cache: 'npm'
-    - name: Install npm dependencies
-      run: npm ci
-    - name: Set up Xcode project and install pod dependencies
-      run: scripts/setup-ios
-    - name: Install fastlane
-      run: bundle install
+    - name: Set up environment (dependencies, Xcode project)
+      run: scripts/setup --ios --ci
     - name: Build the app
       run: bundle exec fastlane build_only
       working-directory: ios

--- a/README.md
+++ b/README.md
@@ -9,5 +9,21 @@ MoneyBoy is a cross-platform app for tracking spending between groups of people.
 
 ## Development
 
-To get started with development, [see here](https://reactnative.dev/docs/environment-setup) for instructions on how to set up the environment.
+First, make sure to have the following installed on your system:
 
+* Node.js and NPM
+* Ruby and Bundler (for Fastlane)
+* Python 3 (for scripts)
+* For iOS development:
+  * Xcode
+  * Homebrew
+* For Android development:
+  * Java
+
+To bootstrap a development environment, run `scripts/setup --ios` or `scripts/setup --android`, depending on which platform you want to build for. This should e.g. generate the corresponding Xcode project and install the required dependencies.
+
+To run the application, you can now e.g. use `npm run ios` or `npm run android`, or directly run the project from Xcode, in case you develop for iOS.
+
+To build the application from the command line, you can use the provided build lanes with `fastlane`, or invoke `xcodebuild`/`gradle` directly. Refer to the [CI workflows](.github/workflows) for examples.
+
+For further instructions, check out [the official docs](https://reactnative.dev/docs/environment-setup).

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ First, make sure to have the following installed on your system:
 * Ruby and Bundler (for Fastlane)
 * Python 3 (for scripts)
 * For iOS development:
-  * Xcode
+  * Xcode 12
   * Homebrew
 * For Android development:
-  * Java
+  * Java 14
 
 To bootstrap a development environment, run `scripts/setup --ios` or `scripts/setup --android`, depending on which platform you want to build for. This should e.g. generate the corresponding Xcode project and install the required dependencies.
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Bootstraps a local development environment.
+
+import argparse
+import shutil
+import subprocess
+import pathlib
+
+# The root directory of the repository
+ROOT = pathlib.Path(__file__).absolute().parent.parent
+
+def run(cmd, **kwargs):
+    subprocess.run(cmd, cwd=ROOT, check=True, **kwargs)
+
+def main():
+    parser = argparse.ArgumentParser(description='Bootstraps a local development environment.')
+
+    parser.add_argument('--ci', action='store_true', help='Uses CI-specific configurations.')
+    parser.add_argument('--ios', action='store_true', help='Sets up the environment for iOS.')
+    parser.add_argument('--android', action='store_true', help='Sets up the environment for Android.')
+
+    args = parser.parse_args()
+
+    if not shutil.which('npm'):
+        print('Please make sure that npm (Node.js) is installed!')
+        exit(1)
+
+    if not shutil.which('bundle'):
+        print('Please make sure that bundler (Ruby) is installed!')
+        exit(1)
+
+    print('==> Installing npm dependencies...')
+    if args.ci:
+        run(['npm', 'install'])
+    else:
+        run(['npm', 'ci'])
+
+    print('==> Installing gem dependencies (e.g. fastlane)...')
+    run(['bundle', 'install'])
+
+    if args.ios:
+        print('==> Setting up iOS environment...')
+        run(['scripts/setup-ios'])
+
+    if args.android:
+        print('==> Setting up Android environment...')
+        run(['scripts/setup-android'])
+
+if __name__ == '__main__':
+    main()

--- a/scripts/setup-android
+++ b/scripts/setup-android
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+# Bootstraps an Android development environment.
+
+set -e
+cd $(dirname $0)/..
+
+# Install Gradle dependencies.
+cd android
+./gradlew dependencies


### PR DESCRIPTION
### Fixes #30, based on #31 

Add a generic `script/setup` that can be invoked with options such as `--ios` or `--android` to bootstrap a local development environment with the required dependencies in a single command.