### PR TITLE
Fix: No/small margin between navbar and bottom edge of screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
-import { StatusBar } from 'react-native';
-
 import { AuthContextProvider } from '@context/AuthContext';
-import AppContainer from '@views/AppContainer';
 import { PescaContextProvider } from '@context/PescaContext';
 import { ThemeContextProvider } from '@context/ThemeContext';
+import AppContainer from '@views/AppContainer';
+import React from 'react';
+import { StatusBar } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 declare const global: { HermesInternal: null | {} };
 
 export default function App() {
   return (
-    <>
+    <SafeAreaProvider>
       <StatusBar barStyle="dark-content" />
       <PescaContextProvider>
         <AuthContextProvider>
@@ -19,6 +19,6 @@ export default function App() {
           </ThemeContextProvider>
         </AuthContextProvider>
       </PescaContextProvider>
-    </>
+    </SafeAreaProvider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "react-native-gesture-handler": "^1.10.3",
         "react-native-modal": "^11.7.0",
         "react-native-reanimated": "^2.2.0",
-        "react-native-safe-area-context": "^3.2.0",
+        "react-native-safe-area-context": "^3.3.0",
         "react-native-screens": "^2.18.1",
         "react-native-tab-view": "^2.16.0",
         "react-native-uuid": "^1.4.9",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-native-gesture-handler": "^1.10.3",
     "react-native-modal": "^11.7.0",
     "react-native-reanimated": "^2.2.0",
-    "react-native-safe-area-context": "^3.2.0",
+    "react-native-safe-area-context": "^3.3.0",
     "react-native-screens": "^2.18.1",
     "react-native-tab-view": "^2.16.0",
     "react-native-uuid": "^1.4.9",

--- a/src/components/navigation/PescaTabBar.tsx
+++ b/src/components/navigation/PescaTabBar.tsx
@@ -6,6 +6,7 @@ import { MaterialTopTabBarProps } from '@react-navigation/material-top-tabs';
 import { Route } from '@react-navigation/native';
 import React, { useContext } from 'react';
 import { SafeAreaView, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { v4 as uuid } from 'react-native-uuid';
 
 type PescaTabUIProps = MaterialTopTabBarProps & {};
@@ -34,6 +35,7 @@ export default function PescaTabBar({ navigation, state }: PescaTabUIProps) {
     );
   }
 
+  const insets = useSafeAreaInsets();
   const theme = useContext(ThemeContext);
   const styles = StyleSheet.create({
     safeAreaView: {
@@ -41,6 +43,7 @@ export default function PescaTabBar({ navigation, state }: PescaTabUIProps) {
     },
     footer: {
       height: 64,
+      marginBottom: insets.bottom ? 0 : 20, // if we are on an older device, use some default padding
     },
     tabBarContainer: {
       flexDirection: 'row',


### PR DESCRIPTION
Closes #27 

Use the module `react-native-safe-area-context` to get the safe-insets of the current device. 
Therefore, a new provider was added around the entire app. In the navbar, the current insets are used to calculate a possibly needed margin between navbar and bottom edge.