### PR TITLE
Update GitHub Actions committer for documentation deployments

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,3 +25,5 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
This will use the `github-actions` bot as committer in automated documentation deployments:

![image](https://user-images.githubusercontent.com/30873659/136865422-efa884ee-bb47-4063-8ea2-5d4ce468e771.png)
