### PR TITLE
Fix: StatusBar styling in dark mode

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,7 +13,7 @@ type AppProps = {};
 export const App: React.FC<AppProps> = () => {
   return (
     <SafeAreaProvider>
-      <StatusBar barStyle="dark-content" />
+      <StatusBar />
       <PescaContextProvider>
         <AuthContextProvider>
           <StyleContextProvider>


### PR DESCRIPTION
Currently, the status bar is always styles dark. Hence, in the newly added dark mode, the status bar is not well visible.